### PR TITLE
add config line needed to ignore localhost.org

### DIFF
--- a/user/kits/redstone.rst
+++ b/user/kits/redstone.rst
@@ -247,6 +247,7 @@ In order to gerrit send email notifications you need to configure it first.
           exim_config::smtp_require_auth: true
           exim_config::smtp_username: 'YOUR_USER'
           exim_config::smtp_password: 'YOUR_PASSWORD'
+          exim_config::queue_smtp_domains: 'localhost.org'
           exim_config::relay_from_hosts:
             - '127.0.0.1'
             - "%{::exim_config::utils::review_ip}"


### PR DESCRIPTION
We can get emails from jenkins ci syste
because in gerrit we use @localhost.org for the jenkins
email address.  Put all messages for this users in a queue.
